### PR TITLE
Updated readme for merge into aws-xray-sdk-hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# **Obsolete**
+This package has now been merged into the official [aws-xray-sdk-node](https://github.com/aws/aws-xray-sdk-node/tree/master/sdk_contrib/hapi)
+
+The new package is available as [aws-xray-sdk-hapi](https://www.npmjs.com/package/aws-xray-sdk-hapi)
+
 # hapi-xray
 [![Known Vulnerabilities](https://snyk.io/test/github/moonthug/hapi-xray/badge.svg?targetFile=package.json)](https://snyk.io/test/github/moonthug/hapi-xray?targetFile=package.json)
 


### PR DESCRIPTION
Updated readme to indicate this package has now been integrated into aws-xray-sdk-node and it's now code and npm location.